### PR TITLE
Add event queue concept to Keyboard, refactor

### DIFF
--- a/src/Keyboard/ScreenKeyboard.ts
+++ b/src/Keyboard/ScreenKeyboard.ts
@@ -1,3 +1,4 @@
+import { getIsModifierKey } from "./isModifierKey";
 import { Keyboard } from "./Keyboard";
 import { KeyCode } from "./types";
 
@@ -93,6 +94,9 @@ export class ScreenKeyboard {
         isAltDown: this.isAltDown,
         isCapsOn: this.isCapsOn,
         isMetaDown: this.isMetaDown,
+        isAutoRepeat: false,
+        char: null,
+        isModifier: getIsModifierKey(code),
       });
     }
   }
@@ -115,6 +119,9 @@ export class ScreenKeyboard {
           isAltDown: this.isAltDown,
           isCapsOn: this.isCapsOn,
           isMetaDown: this.isMetaDown,
+          isAutoRepeat: false,
+          char: null,
+          isModifier: getIsModifierKey(code),
         });
       }
     }

--- a/src/Keyboard/types.ts
+++ b/src/Keyboard/types.ts
@@ -3,7 +3,10 @@ export { KeyCode };
 
 export interface PengKeyboardEvent {
   code: KeyCode;
+  char: string | null;
   pressed: boolean;
+  isAutoRepeat: boolean;
+  isModifier: boolean;
 
   isShiftDown?: boolean;
   isControlDown?: boolean;

--- a/src/Pengputer/PengerShell.ts
+++ b/src/Pengputer/PengerShell.ts
@@ -402,7 +402,6 @@ export class PengerShell implements Executable {
         fileEntry.openType === "run"
       ) {
         std.writeConsole("Running...\n");
-        await std.waitForKeyboardKeysUp();
         fileEntry.data.open();
       } else {
         std.writeConsole(`Not executable\n`);
@@ -458,7 +457,6 @@ export class PengerShell implements Executable {
         fileEntry.openType === "open"
       ) {
         std.writeConsole("Opening...\n");
-        await std.waitForKeyboardKeysUp();
         fileEntry.data.open();
       } else {
         std.writeConsole(`Not readable\n`);

--- a/src/Pengputer/Pengsweeper.ts
+++ b/src/Pengputer/Pengsweeper.ts
@@ -143,6 +143,7 @@ class Pengsweeper extends State {
     std.resetConsole();
     std.clearConsole();
     std.setIsConsoleCursorVisible(false);
+    std.flushKeyboardEvents();
 
     this.needsRedraw = true;
   }
@@ -292,38 +293,43 @@ class Pengsweeper extends State {
   update(dt: number) {
     const { std } = this.pc;
     if (this.getIsFocused()) {
-      if (std.getWasKeyPressed("ArrowRight")) {
-        this.moveCursor({ x: 1, y: 0 });
-      }
-      if (std.getWasKeyPressed("ArrowLeft")) {
-        this.moveCursor({ x: -1, y: 0 });
-      }
-      if (std.getWasKeyPressed("ArrowUp")) {
-        this.moveCursor({ x: 0, y: -1 });
-      }
-      if (std.getWasKeyPressed("ArrowDown")) {
-        this.moveCursor({ x: 0, y: 1 });
-      }
-      if (std.getWasKeyPressed("Space")) {
-        if (this.cursor) {
-          this.openCell(this.cursor);
+      while (true) {
+        const ev = std.getNextKeyboardEvent();
+        if (!ev) break;
+        if (ev.isModifier || !ev.pressed) continue;
+
+        if (ev.code === "ArrowRight") {
+          this.moveCursor({ x: 1, y: 0 });
+        }
+        if (ev.code === "ArrowLeft") {
+          this.moveCursor({ x: -1, y: 0 });
+        }
+        if (ev.code === "ArrowUp") {
+          this.moveCursor({ x: 0, y: -1 });
+        }
+        if (ev.code === "ArrowDown") {
+          this.moveCursor({ x: 0, y: 1 });
+        }
+        if (ev.code === "Space") {
+          if (this.cursor) {
+            this.openCell(this.cursor);
+          }
+        }
+        if (ev.code === "KeyF") {
+          if (this.cursor) {
+            this.toggleCellFlag(this.cursor);
+          }
+        }
+        if (ev.code === "KeyR") {
+          this.signal.emit({ key: "reset" });
+        }
+        if (ev.code === "F1") {
+          this.signal.emit({ key: "help" });
+        }
+        if (ev.code === "Escape") {
+          this.signal.emit({ key: "quit" });
         }
       }
-      if (std.getWasKeyPressed("KeyF")) {
-        if (this.cursor) {
-          this.toggleCellFlag(this.cursor);
-        }
-      }
-      if (std.getWasKeyPressed("KeyR")) {
-        this.signal.emit({ key: "reset" });
-      }
-      if (std.getWasKeyPressed("F1")) {
-        this.signal.emit({ key: "help" });
-      }
-      if (std.getWasKeyPressed("Escape")) {
-        this.signal.emit({ key: "quit" });
-      }
-      std.resetKeyPressedHistory();
     }
 
     if (this.needsRedraw) {
@@ -558,7 +564,7 @@ class Help extends State {
 
     const { std } = this.pc;
 
-    std.resetKeyPressedHistory();
+    std.flushKeyboardEvents();
   }
 
   override onFocus() {
@@ -600,11 +606,13 @@ class Help extends State {
 
     const { std } = this.pc;
 
-    if (std.getWasAnyKeyPressed()) {
-      this.signal.emit({ key: "exit" });
+    while (true) {
+      const ev = std.getNextKeyboardEvent();
+      if (!ev) break;
+      if (!ev.isModifier && ev.pressed) {
+        this.signal.emit({ key: "exit" });
+      }
     }
-
-    std.resetKeyPressedHistory();
   }
 }
 
@@ -648,6 +656,7 @@ class MainMenu extends State {
       fgColor: classicColors["lightSpringGreen"],
     });
     std.resetConsoleAttributes();
+    std.flushKeyboardEvents();
   }
 
   override update(dt: number) {
@@ -659,20 +668,24 @@ class MainMenu extends State {
       return;
     }
 
-    if (std.getWasKeyPressed("Digit1") || std.getWasKeyPressed("Numpad1")) {
-      this.signal.emit({ key: "select", value: "1" });
-    }
-    if (std.getWasKeyPressed("Digit2") || std.getWasKeyPressed("Numpad2")) {
-      this.signal.emit({ key: "select", value: "2" });
-    }
-    if (std.getWasKeyPressed("Digit3") || std.getWasKeyPressed("Numpad3")) {
-      this.signal.emit({ key: "select", value: "3" });
-    }
-    if (std.getWasKeyPressed("Escape")) {
-      this.signal.emit({ key: "exit" });
-    }
+    while (true) {
+      const ev = std.getNextKeyboardEvent();
+      if (!ev) break;
+      if (ev.isModifier || !ev.pressed) continue;
 
-    std.resetKeyPressedHistory();
+      if (ev.code === "Digit1" || ev.code === "Numpad1") {
+        this.signal.emit({ key: "select", value: "1" });
+      }
+      if (ev.code === "Digit2" || ev.code === "Numpad2") {
+        this.signal.emit({ key: "select", value: "2" });
+      }
+      if (ev.code === "Digit3" || ev.code === "Numpad3") {
+        this.signal.emit({ key: "select", value: "3" });
+      }
+      if (ev.code === "Escape") {
+        this.signal.emit({ key: "exit" });
+      }
+    }
   }
 }
 

--- a/src/Pengputer/Tetris.ts
+++ b/src/Pengputer/Tetris.ts
@@ -1216,7 +1216,7 @@ class Tetris implements GameState {
       _.pad("======== P E N G T R I S ========", std.getConsoleSize().w),
     );
 
-    std.resetKeyPressedHistory();
+    std.flushKeyboardEvents();
   }
 
   public onLeave() {}
@@ -1228,25 +1228,32 @@ class Tetris implements GameState {
 
     // input
 
-    if (std.getWasKeyPressed("ArrowUp")) {
-      this.fallingPiece?.rotateRight();
+    while (true) {
+      const ev = std.getNextKeyboardEvent();
+      if (!ev) break;
+      if (ev.isModifier || !ev.pressed || ev.isAutoRepeat) continue;
+
+      if (ev.code === "ArrowUp") {
+        this.fallingPiece?.rotateRight();
+      }
+      if (ev.code === "KeyZ") {
+        this.fallingPiece?.rotateLeft();
+      }
+      if (ev.code === "KeyX") {
+        this.fallingPiece?.rotateRight();
+      }
+      if (ev.code === "KeyC") {
+        this.holdPiece();
+      }
+      if (ev.code === "Space") {
+        this.fallingPiece?.hardDrop();
+      }
+      if (ev.code === "Escape") {
+        this.onQuit.emit();
+        return;
+      }
     }
-    if (std.getWasKeyPressed("KeyZ")) {
-      this.fallingPiece?.rotateLeft();
-    }
-    if (std.getWasKeyPressed("KeyX")) {
-      this.fallingPiece?.rotateRight();
-    }
-    if (std.getWasKeyPressed("KeyC")) {
-      this.holdPiece();
-    }
-    if (std.getWasKeyPressed("Space")) {
-      this.fallingPiece?.hardDrop();
-    }
-    if (std.getWasKeyPressed("Escape")) {
-      this.onQuit.emit();
-      return;
-    }
+
     if (this.fallingPiece) {
       this.fallingPiece.setIsPushdown(std.getIsKeyPressed("ArrowDown"));
       if (std.getIsKeyPressed("ArrowLeft")) {
@@ -1260,7 +1267,6 @@ class Tetris implements GameState {
         this.fallingPiece.setDirection({ x: 0, y: 0 });
       }
     }
-    std.resetKeyPressedHistory();
 
     // logic
 
@@ -1434,12 +1440,17 @@ class MainMenu implements GameState {
   update(dt: number) {
     const { std } = this.pc;
 
-    if (std.getWasKeyPressed("Enter")) {
-      this.onStartGame.emit();
-    } else if (std.getWasKeyPressed("Escape")) {
-      this.onQuit.emit();
+    while (true) {
+      const ev = std.getNextKeyboardEvent();
+      if (!ev) break;
+      if (ev.isModifier || !ev.pressed) continue;
+
+      if (ev.code === "Enter") {
+        this.onStartGame.emit();
+      } else if (ev.code === "Escape") {
+        this.onQuit.emit();
+      }
     }
-    std.resetKeyPressedHistory();
   }
 
   onLeave() {}
@@ -1471,10 +1482,13 @@ class GameOver implements GameState {
   update() {
     const { std } = this.pc;
 
-    if (std.getWasKeyPressed("Escape")) {
+    while (true) {
+      const ev = std.getNextKeyboardEvent();
+      if (!ev) break;
+      if (ev.isModifier || !ev.pressed) continue;
+
       this.onContinue.emit();
     }
-    std.resetKeyPressedHistory();
   }
 
   onLeave() {}
@@ -1494,7 +1508,7 @@ export class TetrisApp implements Executable {
 
   private changeState(newStateKey: GameStateKey) {
     const { std } = this.pc;
-    std.resetKeyPressedHistory();
+    std.flushKeyboardEvents();
     this.currentState?.onLeave();
     switch (newStateKey) {
       case GameStateKey.MainMenu:
@@ -1535,7 +1549,7 @@ export class TetrisApp implements Executable {
   async run(args: string[]) {
     const { std } = this.pc;
 
-    std.resetKeyPressedHistory();
+    std.flushKeyboardEvents();
     this.changeState(GameStateKey.MainMenu);
 
     return new Promise<void>((resolve) => {

--- a/src/Std/Std.ts
+++ b/src/Std/Std.ts
@@ -6,7 +6,7 @@ import { ClickListener } from "../Screen/Screen";
 import { CellAttributes, TextBuffer } from "../TextBuffer";
 import { Vector, vectorAdd } from "../Toolbox/Vector";
 import { Rect } from "../types";
-import { readKey, readLine, waitForKeysUp } from "./readLine";
+import { readKey, readLine } from "./readLine";
 
 export type ConsoleWriteAttributes = Partial<CellAttributes> & {
   reset?: boolean;
@@ -228,36 +228,20 @@ export class Std {
     return readKey(this.keyboard);
   }
 
-  waitForKeyboardKeysUp() {
-    return waitForKeysUp(this.keyboard);
-  }
-
   getIsKeyPressed(keyCode: KeyCode) {
     return this.keyboard.getIsKeyPressed(keyCode);
   }
 
-  getLastKeyPressedOf(keyCodes: KeyCode[]) {
-    return this.keyboard.getLastPressedOf(keyCodes);
+  flushKeyboardEvents() {
+    return this.keyboard.flushEventBuffer();
   }
 
-  addKeyTypeListener(callback: TypeListener) {
-    return this.keyboard.addTypeListener(callback);
+  getNextKeyboardEvent() {
+    return this.keyboard.getNextEvent();
   }
 
-  addAllKeysUpListener(callback: VoidListener) {
-    return this.keyboard.addAllKeysUpListener(callback);
-  }
-
-  getWasKeyPressed(keyCode: KeyCode) {
-    return this.keyboard.getWasKeyPressed(keyCode);
-  }
-
-  getWasAnyKeyPressed() {
-    return this.keyboard.getWasAnyKeyPressed();
-  }
-
-  resetKeyPressedHistory() {
-    return this.keyboard.resetWereKeysPressed();
+  async waitForNextKeyboardEvent() {
+    return await this.keyboard.waitForNextEvent();
   }
 
   /* ===================== MOUSE ========================= */


### PR DESCRIPTION
- Removed "was key pressed" facilities.
- Removed typing listeners.
- Added event queue to Keyboard.
- Reworked readLine, readKey to use event queue.
- Rewrote games to use event queue.
- Updated ScreenKeyboard to be compatible.

See examples in Pengtris or Pengsweeper, also readLine, to see how keyboard events can now be handled.

Basic concept: Keyboard keeps a queue of events. You can either consume them until none are left and continue (`update` in games), or you can get await for event (you get one immediately if one is in the queue) in a loop thus pausing until there are events. Flushing the events helps when switching between states or apps - all keyboard events are cleared.